### PR TITLE
Message constructor helpers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,23 @@ find_package(catkin REQUIRED COMPONENTS
 
 find_package(OpenCV REQUIRED)
 
+add_message_files(
+  FILES
+  LinearPosition.msg
+  LinearVelocity.msg
+  AngularPosition.msg
+  AngularVelocity.msg
+)
+
+
+
+generate_messages(
+  DEPENDENCIES
+  std_msgs
+  mavros_msgs
+  sensor_msgs
+)
+
 catkin_package(
   INCLUDE_DIRS src
   CATKIN_DEPENDS roscpp rospy std_msgs mavros mavros_msgs cv_bridge image_transport sensor_msgs
@@ -39,6 +56,8 @@ install(PROGRAMS
   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )
 
+# Helpers declares libraries that are convenient for building ros messages
+add_subdirectory(src/helpers)
 
 add_subdirectory(src/preprocess)
 

--- a/msg/AngularPosition.msg
+++ b/msg/AngularPosition.msg
@@ -1,0 +1,3 @@
+float32 roll
+float32 pitch
+float32 yaw

--- a/msg/AngularVelocity.msg
+++ b/msg/AngularVelocity.msg
@@ -1,0 +1,3 @@
+float32 droll
+float32 dpitch
+float32 dyaw

--- a/msg/LinearPosition.msg
+++ b/msg/LinearPosition.msg
@@ -1,0 +1,3 @@
+float32 x
+float32 y
+float32 z

--- a/msg/LinearVelocity.msg
+++ b/msg/LinearVelocity.msg
@@ -1,0 +1,3 @@
+float32 dx
+float32 dy
+float32 dz

--- a/src/helpers/AngularPosition.cpp
+++ b/src/helpers/AngularPosition.cpp
@@ -1,0 +1,10 @@
+#include "AngularPosition.h"
+
+robosub::AngularPosition AngularPosition(double roll, double pitch,
+                                         double yaw) {
+  robosub::AngularPosition val;
+  val.roll = roll;
+  val.pitch = pitch;
+  val.yaw = yaw;
+  return val;
+}

--- a/src/helpers/AngularPosition.h
+++ b/src/helpers/AngularPosition.h
@@ -1,0 +1,7 @@
+#ifndef ANGULARPOSITION_H
+#define ANGULARPOSITION_H
+#include "robosub/AngularPosition.h"
+
+robosub::AngularPosition AngularPosition(double roll, double pitch, double yaw);
+
+#endif  // ANGULARPOSITION_H

--- a/src/helpers/AngularVelocity.cpp
+++ b/src/helpers/AngularVelocity.cpp
@@ -1,0 +1,10 @@
+#include "AngularVelocity.h"
+
+robosub::AngularVelocity AngularVelocity(double droll, double dpitch,
+                                         double dyaw) {
+  robosub::AngularVelocity val;
+  val.droll = droll;
+  val.dpitch = dpitch;
+  val.dyaw = dyaw;
+  return val;
+}

--- a/src/helpers/AngularVelocity.h
+++ b/src/helpers/AngularVelocity.h
@@ -1,0 +1,8 @@
+#ifndef ANGULARVELOCITY_H
+#define ANGULARVELOCITY_H
+#include "robosub/AngularVelocity.h"
+
+robosub::AngularVelocity AngularVelocity(double droll, double dpitch,
+                                         double dyaw);
+
+#endif  // ANGULARVELOCITY_H

--- a/src/helpers/Bool.cpp
+++ b/src/helpers/Bool.cpp
@@ -1,0 +1,7 @@
+#include "Bool.h"
+
+std_msgs::Bool Bool(bool data) {
+  std_msgs::Bool val;
+  val.data = data;
+  return val;
+}

--- a/src/helpers/Bool.h
+++ b/src/helpers/Bool.h
@@ -1,0 +1,7 @@
+#ifndef BOOL_H
+#define BOOL_H
+
+#include <std_msgs/Bool.h>
+std_msgs::Bool Bool(bool data);
+
+#endif  // BOOL_H

--- a/src/helpers/CMakeLists.txt
+++ b/src/helpers/CMakeLists.txt
@@ -1,0 +1,3 @@
+# Library containing useful message constructors
+add_library(ctors Vector3.cpp Bool.cpp AngularPosition.cpp AngularVelocity.cpp LinearPosition.cpp LinearVelocity.cpp)
+add_dependencies(ctors ${catkin_EXPORTED_TARGETS} ${${PROJECT_NAME}_EXPORTED_TARGETS})

--- a/src/helpers/LinearPosition.cpp
+++ b/src/helpers/LinearPosition.cpp
@@ -1,0 +1,9 @@
+#include "LinearPosition.h"
+
+robosub::LinearPosition LinearPosition(double x, double y, double z) {
+  robosub::LinearPosition val;
+  val.x = x;
+  val.y = y;
+  val.z = z;
+  return val;
+}

--- a/src/helpers/LinearPosition.h
+++ b/src/helpers/LinearPosition.h
@@ -1,0 +1,7 @@
+#ifndef LINEARPOSITION_H
+#define LINEARPOSITION_H
+#include "robosub/LinearPosition.h"
+
+robosub::LinearPosition LinearPosition(double x, double y, double z);
+
+#endif  // LINEARPOSITION_H

--- a/src/helpers/LinearVelocity.cpp
+++ b/src/helpers/LinearVelocity.cpp
@@ -1,0 +1,9 @@
+#include "LinearVelocity.h"
+
+robosub::LinearVelocity LinearVelocity(double dx, double dy, double dz) {
+  robosub::LinearVelocity val;
+  val.dx = dx;
+  val.dy = dy;
+  val.dz = dz;
+  return val;
+}

--- a/src/helpers/LinearVelocity.h
+++ b/src/helpers/LinearVelocity.h
@@ -1,0 +1,7 @@
+#ifndef LINEARVELOCITY_H
+#define LINEARVELOCITY_H
+#include "robosub/LinearVelocity.h"
+
+robosub::LinearVelocity LinearVelocity(double dx, double dy, double dz);
+
+#endif  // LINEARVELOCITY_H

--- a/src/helpers/Vector3.cpp
+++ b/src/helpers/Vector3.cpp
@@ -1,0 +1,9 @@
+#include "Vector3.h"
+
+geometry_msgs::Vector3 Bool(double x, double y, double z) {
+  geometry_msgs::Vector3 val;
+  val.x = x;
+  val.y = y;
+  val.z = z;
+  return val;
+}

--- a/src/helpers/Vector3.h
+++ b/src/helpers/Vector3.h
@@ -1,0 +1,7 @@
+#ifndef VECTOR3_H
+#define VECTOR3_H
+
+#include <geometry_msgs/Vector3.h>
+geometry_msgs::Vector3 Bool(double x, double y, double z);
+
+#endif  // VECTOR3_H

--- a/src/helpers/param.h
+++ b/src/helpers/param.h
@@ -6,7 +6,7 @@
 
 // Get a parameter. If the parameter is not set, throw an exception
 template <typename T>
-void getParamOrThrow(std::string param, T &target) throw (ros::Exception) {
+void getParamOrThrow(std::string param, T &target) throw(ros::Exception) {
   if (!ros::param::get(param, target)) {
     throw ros::Exception("Parameter " + param + " not specified");
   }

--- a/src/helpers/param.h
+++ b/src/helpers/param.h
@@ -1,0 +1,15 @@
+#ifndef UTIL_H
+#define UTIL_H
+#include <ros/exception.h>
+#include <ros/ros.h>
+#include <string>
+
+// Get a parameter. If the parameter is not set, throw an exception
+template <typename T>
+void getParamOrThrow(std::string param, T &target) throw (ros::Exception) {
+  if (!ros::param::get(param, target)) {
+    throw ros::Exception("Parameter " + param + " not specified");
+  }
+}
+
+#endif  // UTIL_H


### PR DESCRIPTION
Instead of constructing then setting the members of messages, this adds
constructors used like `Bool(true)`

The old way is
```
std_msgs::Bool msg; 
msg.data = true;
```
versus
```
std_msgs::Bool msg = Bool(true);
```